### PR TITLE
Implemented compatibility with feature level 9.1 in D3D11 renderer.

### DIFF
--- a/gfx_direct3d11.cpp
+++ b/gfx_direct3d11.cpp
@@ -1037,7 +1037,7 @@ static void gfx_d3d11_set_sampler_parameters(int tile, bool linear_filter, uint3
     sampler_desc.AddressU = gfx_cm_to_d3d11(cms);
     sampler_desc.AddressV = gfx_cm_to_d3d11(cmt);
     sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
-    sampler_desc.MinLOD = -D3D11_FLOAT32_MAX;
+    sampler_desc.MinLOD = 0;
     sampler_desc.MaxLOD = D3D11_FLOAT32_MAX;
 
     TextureData *texture_data = &d3d.textures[d3d.current_texture_ids[tile]];


### PR DESCRIPTION
- Simplified noise function and more data is passed through constant buffers instead of being calculated per-pixel. They were using more instructions than allowed in level 9.1.
- Get screen coordinates from screen-space vertices instead of SV_Position.
- Increased shader text buffer to 4096 as shaders can be bigger now.
- Changed depth buffer format to DXGI_FORMAT_D24_UNORM_S8_UINT.
- Some other small changes to be compatible with level 9.1.