### PR TITLE
Fixed fade ins and fade outs when noise is active.

### DIFF
--- a/gfx_direct3d_common.cpp
+++ b/gfx_direct3d_common.cpp
@@ -299,7 +299,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
         append_line(buf, &len, "    float2 coords = (input.screenPos.xy / input.screenPos.w) * noise_scale;");
-        append_line(buf, &len, "    texel.a *= round(random(float3(floor(coords), noise_frame)));");
+        append_line(buf, &len, "    texel.a *= round(saturate(random(float3(floor(coords), noise_frame)) + texel.a - 0.5));");
     }
 
     if (cc_features.opt_alpha) {

--- a/gfx_opengl.c
+++ b/gfx_opengl.c
@@ -268,7 +268,7 @@ static struct ShaderProgram *gfx_opengl_create_and_load_new_shader(uint32_t shad
     }
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
-        append_line(fs_buf, &fs_len, "texel.a *= floor(random(vec3(floor(gl_FragCoord.xy * (240.0 / float(window_height))), float(frame_count))) + 0.5);");
+        append_line(fs_buf, &fs_len, "texel.a *= floor(clamp(random(vec3(floor(gl_FragCoord.xy * (240.0 / float(window_height))), float(frame_count))) + texel.a, 0.0, 1.0));");
     }
 
     if (cc_features.opt_alpha) {


### PR DESCRIPTION
Noise effect now resembles more closely to how it works on N64. Tested on D3D11, D3D12 and OpenGL.

Before:
![0](https://user-images.githubusercontent.com/7031754/96270807-66f4db00-0fcc-11eb-8f03-9c8cbabed582.gif)

After:
![1](https://user-images.githubusercontent.com/7031754/96270841-6f4d1600-0fcc-11eb-9fe8-be820cf694ff.gif)
